### PR TITLE
fix undefined desc if name = lchown

### DIFF
--- a/_promisify_all.js
+++ b/_promisify_all.js
@@ -18,7 +18,7 @@ module.exports = function (source, exports, methods) {
 
 function deprecated(source, name) {
   var desc = Object.getOwnPropertyDescriptor(source, name)
-  if (!desc.get) return false
+  if (!desc || !desc.get) return false
   if (desc.get.name === 'deprecated') return true
   return false
 }


### PR DESCRIPTION
I have got an error when I try to use koa-sendfile:

/home/fp/tests/work-base/node_modules/koa-sendfile/node_modules/mz/_promisify_all.js:24
  if (desc.get.name === 'deprecated') return true
          ^
TypeError: Cannot read property 'get' of undefined
    at deprecated (/home/fp/tests/work-base/node_modules/koa-sendfile/node_modules/mz/_promisify_all.js:24:11)
    at /home/fp/tests/work-base/node_modules/koa-sendfile/node_modules/mz/_promisify_all.js:6:9
    at Array.forEach (native)
    at module.exports (/home/fp/tests/work-base/node_modules/koa-sendfile/node_modules/mz/_promisify_all.js:5:11)
    at Object.<anonymous> (/home/fp/tests/work-base/node_modules/koa-sendfile/node_modules/mz/fs.js:4:31)
    at Module._compile (module.js:449:26)

The name which generated the error was "lchown".
