### PR TITLE
use es6-promise polyfill rather than native-or-bluebird

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -1,5 +1,5 @@
 
-var Promise = require('native-or-bluebird')
+var Promise = require('es6-promise').Promise
 var fs
 try {
   fs = require('graceful-fs')

--- a/package.json
+++ b/package.json
@@ -11,13 +11,12 @@
   "license": "MIT",
   "repository": "normalize/mz",
   "dependencies": {
-    "native-or-bluebird": "1",
+    "es6-promise": "^3.0.2",
     "object-assign": "^4.0.1",
     "thenify-all": "1"
   },
   "devDependencies": {
     "istanbul": "0",
-    "bluebird": "2",
     "mocha": "2"
   },
   "scripts": {

--- a/readline.js
+++ b/readline.js
@@ -1,5 +1,5 @@
 var readline = require('readline')
-var Promise = require('native-or-bluebird')
+var Promise = require('es6-promise').Promise
 var objectAssign = require('object-assign')
 var Interface = readline.Interface
 


### PR DESCRIPTION
Ensure behavior is consistent regardless of which other dependencies happen to be installed.