### PR TITLE
feat: add fs.truncate

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -36,6 +36,7 @@ var api = [
   'readFile',
   'writeFile',
   'appendFile',
+  'truncate',
 ]
 
 typeof fs.access === 'function' && api.push('access')


### PR DESCRIPTION
Adds support for wrapping `fs.truncate`.

Left the dangling comma in the array to match the previous style.
Left the unit tests alone (all are passing still, but remain unchanged -- can add tests if necessary).
Looks like `fs.truncate` goes [wayyy back](https://nodejs.org/docs/v0.4.4/api/fs.html#fs.truncate), so I don't believe older versions of node would have issues with this.