### PR TITLE
Test against Node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
 - "iojs-v3"
 - "4"
 - "5"
+- "6"
 sudo: false
 language: node_js
 script: "npm run test-travis"


### PR DESCRIPTION

>   17 passing (4s)
>   2 failing
> 
>   1) readline callback support completer support sync:
>      Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
>   
> 
>   2) readline callback support completer support async:
>      Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
>  