### PR TITLE
Modernize copyFile in enviroments that support it

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -41,6 +41,7 @@ var api = [
 ]
 
 typeof fs.access === 'function' && api.push('access')
+typeof fs.copyFile === 'function' && api.push('copyFile')
 typeof fs.mkdtemp === 'function' && api.push('mkdtemp')
 
 require('thenify-all').withCallback(fs, exports, api)


### PR DESCRIPTION
Node v8.5.0 adds a `copyFile` method: https://nodejs.org/api/fs.html#fs_fs_copyfile_src_dest_flags_callback