### PR TITLE
Updated readme example's async example to use IIFE

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,9 @@ With ES2017, this will allow you to use async functions cleanly with node's core
 ```js
 const fs = require('mz/fs')
 
-
-async function doSomething () {
+(async function () {
   if (await fs.exists(__filename)) // do something
-}
+})()
 ```
 
 ## Promisification


### PR DESCRIPTION
I notice the first example uses a series of statements (which would perform the action), but the second example, showcasing async/await syntax, uses a function definition instead. If someone ran the code examples, they would not do the same thing, especially if one extended the example with statements inside the `if` bodies.

I changed the second example to align with the first. Same style (semicolons, function instead of arrow function, etc), but the second example now also shows code that "does stuff".